### PR TITLE
feat: upgrade secp256k1 to 0.12.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/attaswift/BigInt.git", .upToNextMajor(from: "5.0.0")),
-        .package(url: "https://github.com/horizontalsystems/HsExtensions.Swift.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/horizontalsystems/HsExtensions.Swift.git", .upToNextMinor(from: "1.0.0")),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", exact: .init(0, 12, 2))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://github.com/attaswift/BigInt.git", .upToNextMajor(from: "5.0.0")),
         .package(url: "https://github.com/horizontalsystems/HsExtensions.Swift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
-        .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", exact: .init(0, 10, 0))
+        .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", exact: .init(0, 12, 2))
     ],
     targets: [
         .target(

--- a/Sources/HsCryptoKit/Crypto.swift
+++ b/Sources/HsCryptoKit/Crypto.swift
@@ -72,7 +72,7 @@ public enum Crypto {
     public static func publicKey(_ publicKey: secp256k1_pubkey, compressed: Bool) -> Data {
         var outputLen: Int = compressed ? 33 : 65
 
-        let context = secp256k1.Context.raw
+        let context = secp256k1.Context.rawRepresentation
 
         var publicKey = publicKey
         var output = Data(count: outputLen)
@@ -93,7 +93,7 @@ public enum Crypto {
         case .secp256k1:
             var pubKeyPoint = secp256k1_pubkey()
 
-            let context = secp256k1.Context.raw
+            let context = secp256k1.Context.rawRepresentation
             _ = SecpResult(secp256k1_ec_pubkey_create(context, &pubKeyPoint, privateKey))
 
             return publicKey(pubKeyPoint, compressed: compressed)
@@ -110,7 +110,7 @@ public enum Crypto {
         precondition(data.count > 0, "Data must be non-zero size")
         precondition(privateKey.count > 0, "PrivateKey must be non-zero size")
 
-        let ctx = secp256k1.Context.raw
+        let ctx = secp256k1.Context.rawRepresentation
 
         let signature = UnsafeMutablePointer<secp256k1_ecdsa_signature>.allocate(capacity: 1)
         let status = data.withUnsafeBytes { ptr in
@@ -182,7 +182,7 @@ public enum Crypto {
         // Combine to points to found new point (new public Key)
         var combinedKey = secp256k1_pubkey()
         if withUnsafeMutablePointer(to: &combinedKey, { (combinedKeyPtr: UnsafeMutablePointer<secp256k1_pubkey>) -> Int32 in
-            secp256k1_ec_pubkey_combine(secp256k1.Context.raw, combinedKeyPtr, immutablePointer, 2)
+            secp256k1_ec_pubkey_combine(secp256k1.Context.rawRepresentation, combinedKeyPtr, immutablePointer, 2)
         }) == 0 {
             throw SignError.additionError
         }

--- a/Sources/HsCryptoKit/CryptoSwift/BatchedCollection.swift
+++ b/Sources/HsCryptoKit/CryptoSwift/BatchedCollection.swift
@@ -18,11 +18,11 @@ struct BatchedCollectionIndex<Base: Collection> {
 }
 
 extension BatchedCollectionIndex: Comparable {
-    static func == <Base>(lhs: BatchedCollectionIndex<Base>, rhs: BatchedCollectionIndex<Base>) -> Bool {
+    static func == (lhs: BatchedCollectionIndex<Base>, rhs: BatchedCollectionIndex<Base>) -> Bool {
         return lhs.range.lowerBound == rhs.range.lowerBound
     }
 
-    static func < <Base>(lhs: BatchedCollectionIndex<Base>, rhs: BatchedCollectionIndex<Base>) -> Bool {
+    static func <(lhs: BatchedCollectionIndex<Base>, rhs: BatchedCollectionIndex<Base>) -> Bool {
         return lhs.range.lowerBound < rhs.range.lowerBound
     }
 }

--- a/Sources/HsCryptoKit/EllipticCurveEncrypterSecp256k1.swift
+++ b/Sources/HsCryptoKit/EllipticCurveEncrypterSecp256k1.swift
@@ -7,7 +7,7 @@ final class EllipticCurveEncrypterSecp256k1 {
     private let context: OpaquePointer
 
     init() {
-        context = secp256k1.Context.raw
+        context = secp256k1.Context.rawRepresentation
     }
 
     /// Signs the hash with the private key. Produces signature data structure that can be exported with


### PR DESCRIPTION
This upgrades secp256k1 from 0.10.0 to 0.12.2.
Additionally a warning was fixed that would be an error in swift 6.